### PR TITLE
fixed invalid .cmd syntax

### DIFF
--- a/start.cmd
+++ b/start.cmd
@@ -19,12 +19,12 @@ if exist PocketMine-MP.phar (
 	)
 )
 
-#if exist bin\php\php_wxwidgets.dll (
-#	%PHP_BINARY% %POCKETMINE_FILE% --enable-gui %*
-#) else (
+::if exist bin\php\php_wxwidgets.dll (
+::	%PHP_BINARY% %POCKETMINE_FILE% --enable-gui %*
+::) else (
 	if exist bin\mintty.exe (
 		start "" bin\mintty.exe -o Columns=88 -o Rows=32 -o AllowBlinking=0 -o FontQuality=3 -o Font="DejaVu Sans Mono" -o FontHeight=10 -o CursorType=0 -o CursorBlinks=1 -h error -t "PocketMine-MP" -i bin/pocketmine.ico -w max %PHP_BINARY% %POCKETMINE_FILE% --enable-ansi %*
 	) else (
 		%PHP_BINARY% -c bin\php %POCKETMINE_FILE% %*
 	)
-#)
+::)


### PR DESCRIPTION
CMD uses :: instead of # to comment a code.